### PR TITLE
Kfp v2

### DIFF
--- a/elyra/metadata/schemasproviders.py
+++ b/elyra/metadata/schemasproviders.py
@@ -23,12 +23,6 @@ from typing import List
 import entrypoints
 from traitlets import log  # noqa H306
 
-try:
-    from kfp_tekton import TektonClient
-except ImportError:
-    # We may not have kfp-tekton available and that's okay!
-    TektonClient = None
-
 from elyra.metadata.schema import SchemasProvider
 from elyra.metadata.schemaspaces import CodeSnippets
 from elyra.metadata.schemaspaces import ComponentCatalogs
@@ -95,14 +89,13 @@ class RuntimesSchemas(ElyraSchemasProvider):
         if kfp_schema_present:  # Update the kfp engine enum to reflect current packages...
             # If TektonClient package is missing, navigate to the engine property
             # and remove 'tekton' entry if present and return updated result.
-            if not TektonClient:
-                # locate the schema and update the enum
-                for schema in runtime_schemas:
-                    if schema["name"] == "kfp":
-                        engine_enum: list = schema["properties"]["metadata"]["properties"]["engine"]["enum"]
-                        if "Tekton" in engine_enum:
-                            engine_enum.remove("Tekton")
-                            schema["properties"]["metadata"]["properties"]["engine"]["enum"] = engine_enum
+            # locate the schema and update the enum
+            for schema in runtime_schemas:
+                if schema["name"] == "kfp":
+                    engine_enum: list = schema["properties"]["metadata"]["properties"]["engine"]["enum"]
+                    if "Tekton" in engine_enum:
+                        engine_enum.remove("Tekton")
+                        schema["properties"]["metadata"]["properties"]["engine"]["enum"] = engine_enum
 
             # For KFP schemas replace placeholders:
             # - properties.metadata.properties.auth_type.enum ({AUTH_PROVIDER_PLACEHOLDERS})

--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -27,9 +27,9 @@ from typing import Optional
 from typing import Tuple
 from urllib.parse import urlsplit
 
-from kfp.auth import KF_PIPELINES_SA_TOKEN_ENV
-from kfp.auth import KF_PIPELINES_SA_TOKEN_PATH
-from kfp.auth import ServiceAccountTokenVolumeCredentials
+from kfp.client import KF_PIPELINES_SA_TOKEN_ENV
+from kfp.client import KF_PIPELINES_SA_TOKEN_PATH
+from kfp.client import ServiceAccountTokenVolumeCredentials
 import requests
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "yaspin",
     # see: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli
     "appengine-python-standard",
-    "kfp>=1.7.0,<2.0,!=1.7.2",  # We cap the SDK to <2.0 due to possible breaking changes
+    "kfp>=2.0.1",
     "pygithub",
     "black>=22.8.0",
 ]
@@ -85,10 +85,6 @@ test = [
     "pytest_virtualenv",
     "requests-mock",
     "requests-unixsocket",
-    "kfp-tekton"
-]
-kfp-tekton = [
-    "kfp-tekton>=1.5.2"  # requires kfp >= 1.8.19, which contains fix for Jupyterlab
 ]
 kfp-examples = [
     "elyra-examples-kfp-catalog"
@@ -98,7 +94,6 @@ gitlab = [
 ]
 # The following is a collection of "non-test" extra dependencies from above.
 all = [
-    "kfp-tekton>=1.5.2",
     "elyra-examples-kfp-catalog",
     "python-gitlab",
 ]


### PR DESCRIPTION
Steps to test:

1. Uninstall elyra from your local
```
pip uninstall elyra
```
2. Run `make install-server`
3. Check version of elyra, you should see something like:
```
Name: elyra
Version: 3.16.0.dev0
Summary: Elyra provides AI Centric extensions to JupyterLab
Home-page: 
Author: 
Author-email: 
License: 
Location: /Users/rkpattnaik780/.pyenv/versions/3.10.0/lib/python3.10/site-packages
Requires: appengine-python-standard, autopep8, black, click, colorama, deprecation, entrypoints, jinja2, jsonschema, jupyter-client, jupyter-core, jupyter-events, jupyter-packaging, jupyter-resource-usage, jupyter-server, jupyterlab, jupyterlab-git, jupyterlab-lsp, kfp, markupsafe, minio, nbclient, nbconvert, nbdime, nbformat, networkx, papermill, pygithub, python-lsp-server, pyyaml, requests, rfc3986-validator, tornado, traitlets, typing-extensions, urllib3, watchdog, websocket-client, yaspin
Required-by:
```